### PR TITLE
Libgit2 khash extensions

### DIFF
--- a/khash.h
+++ b/khash.h
@@ -531,6 +531,34 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key)
  */
 #define kh_n_buckets(h) ((h)->n_buckets)
 
+/*! @function
+  @abstract     Iterate over the entries in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  kvar  Variable to which key will be assigned
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach(h, kvar, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(kvar) = kh_key(h,__i);								\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/*! @function
+  @abstract     Iterate over the values in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach_value(h, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
 /* More conenient interfaces */
 
 /*! @function


### PR DESCRIPTION
Hey there!

For https://github.com/libgit2/libgit2 we replaced our hashtable implementation with khash a few months ago and it has been great for us! Thank you! :heart_eyes:

We had to make a few changes to allow us to embed khash into libgit2 and I thought they might be useful to push back upstream.  I've split this into 5 separate commits, but there are really 3 main things we were trying to achieve:
1. make khash easier to embed with separate macros for typedefs, function prototypes, memory allocation and inlining
2. add allocation failure checking (which changes the return value of `kh_resize_ ## name`)
3. add a couple of `foreach` macros for iterating over the keys and values stored in the hash

You are welcome to take all, some, or none of this, as you like. If you'd prefer me to split this into separate pull requests or change the way it's written or anything else, just let me know, but I thought it might be easier to show everything in one place at first.
