### PR TITLE
Enable passing of named structs in functions

### DIFF
--- a/kvec.h
+++ b/kvec.h
@@ -53,6 +53,10 @@ int main() {
 #define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
 
 #define kvec_t(type) struct { size_t n, m; type *a; }
+
+#define kvec_init_t(type, name) struct kvec_struct_name_##name { size_t n, m; type *a; };
+#define kvec_type_t(name) struct kvec_struct_name_##name
+
 #define kv_init(v) ((v).n = (v).m = 0, (v).a = 0)
 #define kv_destroy(v) free((v).a)
 #define kv_A(v, i) ((v).a[(i)])


### PR DESCRIPTION
I wanted to pass around a list of vecs but gcc complains about anonymous structs.
Here is my solution, any thoughts?

Use kvec_init_t(type_name) to create a named struct.
Use kvec_type_t(type_name) as the type.

Example:

// make type
kvec_init_t(int, ints_vec)

int add_ints(kvec_type_t(ints_vec) *my_ints, int uport) {
  // function body
}
