### PR TITLE
Error checking + updates from htslib

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -67,15 +67,22 @@ int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
 	n = 0; max = *_max; offsets = *_offsets;
 	l = strlen(s);
 	
-#define __ksplit_aux do {												\
-		if (_offsets) {													\
-			s[i] = 0;													\
-			if (n == max) {												\
-				max = max? max<<1 : 2;									\
-				offsets = (int*)realloc(offsets, sizeof(int) * max);	\
-			}															\
-			offsets[n++] = last_start;									\
-		} else ++n;														\
+#define __ksplit_aux do {						\
+		if (_offsets) {						\
+			s[i] = 0;					\
+			if (n == max) {					\
+				int *tmp;				\
+				max = max? max<<1 : 2;			\
+				if ((tmp = (int*)realloc(offsets, sizeof(int) * max))) {  \
+					offsets = tmp;			\
+				} else	{				\
+					free(offsets);			\
+					*_offsets = NULL;		\
+					return 0;			\
+				}					\
+			}						\
+			offsets[n++] = last_start;			\
+		} else ++n;						\
 	} while (0)
 
 	for (i = 0, last_char = last_start = 0; i <= l; ++i) {


### PR DESCRIPTION
3-way merge between changes in https://github.com/jkbonfield/htslib/tree/develop/htslib, changes applied by myself to add error checking and ks_str/ks_len functions, and some upstream updates in attractivechaos/klib that had appeared since the initial copy into htslib.

~James

Merged with attractivechaos/klib:
- add upstream kvsprintf and rework ksprintf
- add upstream printf attribute checks
- use our kputw (has MIN_INT bug fix)
- keep our extra functions (kputc_, kputsn_, kputl)

Added ks_str and ks_len functions for tidier manipulation of
internals.

Added error checking to all functions that allocate memory and could
potentially fail; ie return EOF or negative values as per stdio
equivalents.
