### PR TITLE
Make ks_resize(&kstr,kstr.l+1) useful for ensuring the string is allocated and NUL-terminated

### DIFF
--- a/kstring.h
+++ b/kstring.h
@@ -43,6 +43,15 @@
 #endif
 
 
+/* kstring_t is a simple non-opaque type whose fields are likely to be
+ * used directly by user code (but see also ks_str() and ks_len() below).
+ * A kstring_t object is initialised by either of
+ *       kstring_t str = { 0, 0, NULL };
+ *       kstring_t str; ...; str.l = str.m = 0; str.s = NULL;
+ * and either ownership of the underlying buffer should be given away before
+ * the object disappears (i.e., the str.s pointer copied and something else
+ * responsible for freeing it), or the kstring_t should be destroyed with
+ *       free(str.s);  */
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
 typedef struct __kstring_t {


### PR DESCRIPTION
For example, htslib/sam.c's `sam_hdr_read()` calls `sam_hdr_parse(0, NULL)` when the SAM file has no header lines.  This crashes, while `sam_hdr_parse(0, "")` would be correct.

I also attempted to add `ks_init(kstring_t*)` and `ks_destroy(kstring_t*)` functions as wrappers so client code would not need to know exactly which fields to initialise to 0/NULL and which to free.  However these names are unfortunately already taken by `kstream_t` in kseq.h.

Any thoughts about what to do here?  Probably `kstring_t` is simple enough that a comment showing what to set to zero suffices.  Another option would be to add a macro like the following to kstring.h:

```
#define EMPTY_KSTRING { 0, 0, NULL }
```

so that client code could write

```
kstring_t str = EMPTY_KSTRING;
```

I would be happy to add a init/destroy comment or such a macro to this pull request.
