### PR TITLE
Update ksort.h

### DIFF
--- a/ksort.h
+++ b/ksort.h
@@ -147,7 +147,7 @@ typedef struct {
 			tmp = *l; *l = l[i]; l[i] = tmp; ks_heapadjust_##name(0, i, l); \
 		}																\
 	}																	\
-	inline void __ks_insertsort_##name(type_t *s, type_t *t)			\
+	static inline void __ks_insertsort_##name(type_t *s, type_t *t)			\
 	{																	\
 		type_t *i, *j, swap_tmp;										\
 		for (i = s + 1; i < t; ++i)										\


### PR DESCRIPTION
From my personal communication, I got this suggestion:

 using inline incorrectly: see the C99 standard §6.7.4.  Please change to static inline (and report upstream). This also caused some clang compilation problem.
