### PR TITLE
Silence -Wstrict-prototypes and static analyser warnings in klist.h

### DIFF
--- a/klist.h
+++ b/klist.h
@@ -33,7 +33,7 @@
 		size_t cnt, n, max;												\
 		kmptype_t **buf;												\
 	} kmp_##name##_t;													\
-	static inline kmp_##name##_t *kmp_init_##name() {					\
+	static inline kmp_##name##_t *kmp_init_##name(void) {				\
 		return calloc(1, sizeof(kmp_##name##_t));						\
 	}																	\
 	static inline void kmp_destroy_##name(kmp_##name##_t *mp) {			\
@@ -52,7 +52,7 @@
 		--mp->cnt;														\
 		if (mp->n == mp->max) {											\
 			mp->max = mp->max? mp->max<<1 : 16;							\
-			mp->buf = realloc(mp->buf, sizeof(void*) * mp->max);		\
+			mp->buf = realloc(mp->buf, sizeof(kmptype_t *) * mp->max);	\
 		}																\
 		mp->buf[mp->n++] = p;											\
 	}
@@ -75,7 +75,7 @@
 		kmp_##name##_t *mp;												\
 		size_t size;													\
 	} kl_##name##_t;													\
-	static inline kl_##name##_t *kl_init_##name() {						\
+	static inline kl_##name##_t *kl_init_##name(void) {					\
 		kl_##name##_t *kl = calloc(1, sizeof(kl_##name##_t));			\
 		kl->mp = kmp_init(name);										\
 		kl->head = kl->tail = kmp_alloc(name, kl->mp);					\


### PR DESCRIPTION
- Using "(void)" provides an explicit there-are-no-arguments prototype.
- Using the exact type in "malloc(...sizeof)" is clearer and silences warnings from clang's static analyzer.
