### PR TITLE
Don't call freeaddrinfo() when getaddrinfo() fails

### DIFF
--- a/knetfile.c
+++ b/knetfile.c
@@ -87,7 +87,7 @@ static int socket_connect(const char *host, const char *port)
 {
 #define __err_connect(func) do { perror(func); freeaddrinfo(res); return -1; } while (0)
 
-	int on = 1, fd;
+	int ai_err, on = 1, fd;
 	struct linger lng = { 0, 0 };
 	struct addrinfo hints, *res = 0;
 	memset(&hints, 0, sizeof(struct addrinfo));
@@ -95,7 +95,7 @@ static int socket_connect(const char *host, const char *port)
 	hints.ai_socktype = SOCK_STREAM;
 	/* In Unix/Mac, getaddrinfo() is the most convenient way to get
 	 * server information. */
-	if (getaddrinfo(host, port, &hints, &res) != 0) __err_connect("getaddrinfo");
+	if ((ai_err = getaddrinfo(host, port, &hints, &res)) != 0) { fprintf(stderr, "can't resolve %s:%s: %s\n", host, port, gai_strerror(ai_err)); return -1; }
 	if ((fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) __err_connect("socket");
 	/* The following two setsockopt() are used by ftplib
 	 * (http://nbpfaus.net/~pfau/ftplib/). I am not sure if they

--- a/kopen.c
+++ b/kopen.c
@@ -37,13 +37,13 @@ static int socket_connect(const char *host, const char *port)
 {
 #define __err_connect(func) do { perror(func); freeaddrinfo(res); return -1; } while (0)
 
-	int on = 1, fd;
+	int ai_err, on = 1, fd;
 	struct linger lng = { 0, 0 };
 	struct addrinfo hints, *res = 0;
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
-	if (getaddrinfo(host, port, &hints, &res) != 0) __err_connect("getaddrinfo");
+	if ((ai_err = getaddrinfo(host, port, &hints, &res)) != 0) { fprintf(stderr, "can't resolve %s:%s: %s\n", host, port, gai_strerror(ai_err)); return -1; }
 	if ((fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) __err_connect("socket");
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) __err_connect("setsockopt");
 	if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &lng, sizeof(lng)) == -1) __err_connect("setsockopt");


### PR DESCRIPTION
POSIX is somewhat unclear here, but doing so segfaults on some platforms.  Hat tip Kamil Slowikowski @slowkow.  Instead print a more detailed error message using gai_strerror().

This is a **klib** fix for lh3/samtools#21; see also http://sourceforge.net/p/samtools/mailman/message/32229136/