### PR TITLE
Enable overriding kh_inline from user code

### DIFF
--- a/khash.h
+++ b/khash.h
@@ -143,11 +143,13 @@ typedef unsigned long khint64_t;
 typedef unsigned long long khint64_t;
 #endif
 
+#ifndef kh_inline
 #ifdef _MSC_VER
 #define kh_inline __inline
 #else
 #define kh_inline inline
 #endif
+#endif /* kh_inline */
 
 typedef khint32_t khint_t;
 typedef khint_t khiter_t;


### PR DESCRIPTION
I've recently been busy with upgrading [pandas](/pydata/pandas) variant of khash to 0.2.8 and some of its changes over vanilla code could be moved to user code with minimal effort. One of them is supporting custom `kh_inline` definitions: `PANDAS_INLINE` detection macro is somewhat more complicated  than the one used in `khash.h`, this PR enables using it without modifying khash code by doing

``` c
#define kh_inline PANDAS_INLINE
#include <khash.h>
```
