### PR TITLE
khash_test: Fix timing printout in ht_khash_str()

### DIFF
--- a/test/khash_test.c
+++ b/test/khash_test.c
@@ -81,7 +81,7 @@ void ht_khash_str()
 		k = kh_put(str, h, data[i], &ret);
 		if (!ret) kh_del(str, h, k);
 	}
-	printf("[ht_khash_int] size: %u\n", kh_size(h));
+	printf("[ht_khash_str] size: %u\n", kh_size(h));
 	kh_destroy(str, h);
 }
 


### PR DESCRIPTION
The original printed "ht_khash_int" instead of "ht_khash_str".