### PR TITLE
Prevent unused function warnings in khash.h, klist.h

### DIFF
--- a/khash.h
+++ b/khash.h
@@ -151,6 +151,14 @@ typedef unsigned long long khint64_t;
 #endif
 #endif /* kh_inline */
 
+#ifndef klib_unused
+#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+#define klib_unused __attribute__ ((__unused__))
+#else
+#define klib_unused
+#endif
+#endif /* klib_unused */
+
 typedef khint32_t khint_t;
 typedef khint_t khiter_t;
 
@@ -355,7 +363,7 @@ static const double __ac_HASH_UPPER = 0.77;
 	__KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
 
 #define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
-	KHASH_INIT2(name, static kh_inline, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+	KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
 
 /* --- BEGIN OF HASH FUNCTIONS --- */
 

--- a/klist.h
+++ b/klist.h
@@ -28,27 +28,35 @@
 
 #include <stdlib.h>
 
-#define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f)						\
+#ifndef klib_unused
+#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+#define klib_unused __attribute__ ((__unused__))
+#else
+#define klib_unused
+#endif
+#endif /* klib_unused */
+
+#define KMEMPOOL_INIT2(SCOPE, name, kmptype_t, kmpfree_f)				\
 	typedef struct {													\
 		size_t cnt, n, max;												\
 		kmptype_t **buf;												\
 	} kmp_##name##_t;													\
-	static inline kmp_##name##_t *kmp_init_##name(void) {				\
+	SCOPE kmp_##name##_t *kmp_init_##name(void) {						\
 		return calloc(1, sizeof(kmp_##name##_t));						\
 	}																	\
-	static inline void kmp_destroy_##name(kmp_##name##_t *mp) {			\
+	SCOPE void kmp_destroy_##name(kmp_##name##_t *mp) {					\
 		size_t k;														\
 		for (k = 0; k < mp->n; ++k) {									\
 			kmpfree_f(mp->buf[k]); free(mp->buf[k]);					\
 		}																\
 		free(mp->buf); free(mp);										\
 	}																	\
-	static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {		\
+	SCOPE kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {				\
 		++mp->cnt;														\
 		if (mp->n == 0) return calloc(1, sizeof(kmptype_t));			\
 		return mp->buf[--mp->n];										\
 	}																	\
-	static inline void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) { \
+	SCOPE void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) {		\
 		--mp->cnt;														\
 		if (mp->n == mp->max) {											\
 			mp->max = mp->max? mp->max<<1 : 16;							\
@@ -57,32 +65,35 @@
 		mp->buf[mp->n++] = p;											\
 	}
 
+#define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f)						\
+	KMEMPOOL_INIT2(static inline klib_unused, name, kmptype_t, kmpfree_f)
+
 #define kmempool_t(name) kmp_##name##_t
 #define kmp_init(name) kmp_init_##name()
 #define kmp_destroy(name, mp) kmp_destroy_##name(mp)
 #define kmp_alloc(name, mp) kmp_alloc_##name(mp)
 #define kmp_free(name, mp, p) kmp_free_##name(mp, p)
 
-#define KLIST_INIT(name, kltype_t, kmpfree_t)							\
+#define KLIST_INIT2(SCOPE, name, kltype_t, kmpfree_t)					\
 	struct __kl1_##name {												\
 		kltype_t data;													\
 		struct __kl1_##name *next;										\
 	};																	\
 	typedef struct __kl1_##name kl1_##name;								\
-	KMEMPOOL_INIT(name, kl1_##name, kmpfree_t)							\
+	KMEMPOOL_INIT2(SCOPE, name, kl1_##name, kmpfree_t)					\
 	typedef struct {													\
 		kl1_##name *head, *tail;										\
 		kmp_##name##_t *mp;												\
 		size_t size;													\
 	} kl_##name##_t;													\
-	static inline kl_##name##_t *kl_init_##name(void) {					\
+	SCOPE kl_##name##_t *kl_init_##name(void) {							\
 		kl_##name##_t *kl = calloc(1, sizeof(kl_##name##_t));			\
 		kl->mp = kmp_init(name);										\
 		kl->head = kl->tail = kmp_alloc(name, kl->mp);					\
 		kl->head->next = 0;												\
 		return kl;														\
 	}																	\
-	static inline void kl_destroy_##name(kl_##name##_t *kl) {			\
+	SCOPE void kl_destroy_##name(kl_##name##_t *kl) {					\
 		kl1_##name *p;													\
 		for (p = kl->head; p != kl->tail; p = p->next)					\
 			kmp_free(name, kl->mp, p);									\
@@ -90,13 +101,13 @@
 		kmp_destroy(name, kl->mp);										\
 		free(kl);														\
 	}																	\
-	static inline kltype_t *kl_pushp_##name(kl_##name##_t *kl) {		\
+	SCOPE kltype_t *kl_pushp_##name(kl_##name##_t *kl) {				\
 		kl1_##name *q, *p = kmp_alloc(name, kl->mp);					\
 		q = kl->tail; p->next = 0; kl->tail->next = p; kl->tail = p;	\
 		++kl->size;														\
 		return &q->data;												\
 	}																	\
-	static inline int kl_shift_##name(kl_##name##_t *kl, kltype_t *d) { \
+	SCOPE int kl_shift_##name(kl_##name##_t *kl, kltype_t *d) {			\
 		kl1_##name *p;													\
 		if (kl->head->next == 0) return -1;								\
 		--kl->size;														\
@@ -105,6 +116,9 @@
 		kmp_free(name, kl->mp, p);										\
 		return 0;														\
 	}
+
+#define KLIST_INIT(name, kltype_t, kmpfree_t)							\
+	KLIST_INIT2(static inline klib_unused, name, kltype_t, kmpfree_t)
 
 #define kliter_t(name) kl1_##name
 #define klist_t(name) kl_##name##_t


### PR DESCRIPTION
Recent versions of Clang warn about unused static inline functions in .c files (though they suppress this warning for such definitions in header files).  Definitions via KHASH_INIT etc are effectively in the .c file, and it's impractical to make these inline other than static inline; so add attributes to suppress these warnings.

See for example the warnings that drown out other information in [travis htslib build logs](https://travis-ci.org/samtools/htslib/jobs/55008028).