### PR TITLE
Add kstring kgetline() and ks_release() functions

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -105,6 +105,26 @@ int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
 	return n;
 }
 
+int kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp)
+{
+	size_t l0 = s->l;
+
+	while (s->l == l0 || s->s[s->l-1] != '\n') {
+		if (s->m - s->l < 200) ks_resize(s, s->m + 200);
+		if (fgets_fn(s->s + s->l, s->m - s->l, fp) == NULL) break;
+		s->l += strlen(s->s + s->l);
+	}
+
+	if (s->l == l0) return EOF;
+
+	if (s->l > l0 && s->s[s->l-1] == '\n') {
+		s->l--;
+		if (s->l > l0 && s->s[s->l-1] == '\r') s->l--;
+	}
+	s->s[s->l] = '\0';
+	return 0;
+}
+
 /**********************
  * Boyer-Moore search *
  **********************/

--- a/kstring.h
+++ b/kstring.h
@@ -49,9 +49,8 @@
  *       kstring_t str = { 0, 0, NULL };
  *       kstring_t str; ...; str.l = str.m = 0; str.s = NULL;
  * and either ownership of the underlying buffer should be given away before
- * the object disappears (i.e., the str.s pointer copied and something else
- * responsible for freeing it), or the kstring_t should be destroyed with
- *       free(str.s);  */
+ * the object disappears (see ks_release() below) or the kstring_t should be
+ * destroyed with  free(str.s);  */
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
 typedef struct __kstring_t {
@@ -109,6 +108,18 @@ static inline char *ks_str(kstring_t *s)
 static inline size_t ks_len(kstring_t *s)
 {
 	return s->l;
+}
+
+// Give ownership of the underlying buffer away to something else (making
+// that something else responsible for freeing it), leaving the kstring_t
+// empty and ready to be used again, or ready to go out of scope without
+// needing  free(str.s)  to prevent a memory leak.
+static inline char *ks_release(kstring_t *s)
+{
+	char *ss = s->s;
+	s->l = s->m = 0;
+	s->s = NULL;
+	return ss;
 }
 
 static inline int kputsn(const char *p, int l, kstring_t *s)

--- a/kstring.h
+++ b/kstring.h
@@ -82,6 +82,13 @@ extern "C" {
 	 * if sep is not changed. */
 	char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux);
 
+	/* kgetline() uses the supplied fgets()-like function to read a "\n"-
+	 * or "\r\n"-terminated line from fp.  The line read is appended to the
+	 * kstring without its terminator and 0 is returned; EOF is returned at
+	 * EOF or on error (determined by querying fp, as per fgets()). */
+	typedef char *kgets_func(char *, int, void *);
+	int kgetline(kstring_t *s, kgets_func *fgets, void *fp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/kstring_test.c
+++ b/test/kstring_test.c
@@ -1,4 +1,5 @@
 #include <limits.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,7 +38,40 @@ void test_kputl(kstring_t *ks, long n)
 	check("kputl()", ks, buf);
 }
 
-int main()
+static char *mem_gets(char *buf, int buflen, void *vtextp)
+{
+	const char **textp = (const char **) vtextp;
+
+	const char *nl = strchr(*textp, '\n');
+	size_t n = nl? nl - *textp + 1 : strlen(*textp);
+
+	if (n == 0) return NULL;
+
+	if (n > buflen-1) n = buflen-1;
+	memcpy(buf, *textp, n);
+	buf[n] = '\0';
+	*textp += n;
+	return buf;
+}
+
+void test_kgetline(kstring_t *ks, const char *text, ...)
+{
+	const char *exp;
+	va_list arg;
+
+	va_start(arg, text);
+	while ((exp = va_arg(arg, const char *)) != NULL) {
+		ks->l = 0;
+		if (kgetline(ks, mem_gets, &text) != 0) kputs("EOF", ks);
+		check("kgetline()", ks, exp);
+	}
+	va_end(arg);
+
+	ks->l = 0;
+	if (kgetline(ks, mem_gets, &text) == 0) check("kgetline()", ks, "EOF");
+}
+
+int main(int argc, char **argv)
 {
 	kstring_t ks;
 
@@ -64,6 +98,28 @@ int main()
 	test_kputl(&ks, LONG_MAX);
 	test_kputl(&ks, -LONG_MAX);
 	test_kputl(&ks, LONG_MIN);
+
+	test_kgetline(&ks, "", NULL);
+	test_kgetline(&ks, "apple", "apple", NULL);
+	test_kgetline(&ks, "banana\n", "banana", NULL);
+	test_kgetline(&ks, "carrot\r\n", "carrot", NULL);
+	test_kgetline(&ks, "\n", "", NULL);
+	test_kgetline(&ks, "\n\n", "", "", NULL);
+	test_kgetline(&ks, "foo\nbar", "foo", "bar", NULL);
+	test_kgetline(&ks, "foo\nbar\n", "foo", "bar", NULL);
+	test_kgetline(&ks,
+		"abcdefghijklmnopqrstuvwxyz0123456789\nABCDEFGHIJKLMNOPQRSTUVWXYZ\n",
+		"abcdefghijklmnopqrstuvwxyz0123456789",
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ", NULL);
+
+	if (argc > 1) {
+		FILE *f = fopen(argv[1], "r");
+		if (f) {
+			for (ks.l = 0; kgetline(&ks, (kgets_func *)fgets, f) == 0; ks.l = 0)
+				puts(ks.s);
+			fclose(f);
+		}
+	}
 
 	free(ks.s);
 


### PR DESCRIPTION
Add new `kgetline()` function that reads an arbitrarily-long line from a stream without concerning the caller about buffer sizes, managing the memory in a kstring instead.  e.g., to read from a stdio FILE pointer:

    kgetline(&kstr, (kgets_func *) fgets, fp)

or write a suitable `kgets_func` to read from other kinds of files.

Using BSD's `getline()` is not super-portable (see samtools/samtools#392) and tedious when you're already using kstrings elsewhere.  Klib already has `ks_getuntil()` which can be used to read a line, but it's overkill for simple cases of wanting to read a file line by line, and kseq.h does not have enough `static inline` and `##typename` trickery (cf https://bugs.debian.org/746164) so some code may wish to avoid it.

----

This PR also includes `ks_release()` from the previous now-closed PR #30:

Using this function is a more explicit way of transferring ownership than just `foo = str.s`; the latter leaves room for readers to wonder whether a subsequent `free(str.s)` has been forgotten.

For an example of it in use, see https://github.com/samtools/samtools/blob/develop/bam_sort.c