### PR TITLE
Update kvec_test.cc

### DIFF
--- a/test/kvec_test.cc
+++ b/test/kvec_test.cc
@@ -53,7 +53,7 @@ int main()
 	t = clock();
 	for (i = 0; i < M; ++i) {
 		std::vector<int> array;
-		array.reserve(N);
+		array.resize(N);
 		for (j = 0; j < N; ++j) array[j] = j;
 	}
 	printf("C++ vector, preallocated: %.3f sec\n",


### PR DESCRIPTION
vector.reserve() won't change size of vector, indexing after reserve may cause problem. it didn't fail before because there's no bound checking performed with operator[].