### PR TITLE
Fix kstrtok finished flag check, undefined behaviour and sign extension issues

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -38,7 +38,7 @@ char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux)
 {
 	const char *p, *start;
 	if (sep) { // set up the table
-		if (str == 0 && (aux->tab[0]&1)) return 0; // no need to set up if we have finished
+		if (str == 0 && aux->finished) return 0; // no need to set up if we have finished
 		aux->finished = 0;
 		if (sep[1]) {
 			aux->sep = -1;

--- a/kstring.c
+++ b/kstring.c
@@ -34,28 +34,29 @@ int ksprintf(kstring_t *s, const char *fmt, ...)
 	return l;
 }
 
-char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux)
+char *kstrtok(const char *str, const char *sep_in, ks_tokaux_t *aux)
 {
-	const char *p, *start;
+	const unsigned char *p, *start, *sep = (unsigned char *) sep_in;
 	if (sep) { // set up the table
 		if (str == 0 && aux->finished) return 0; // no need to set up if we have finished
 		aux->finished = 0;
-		if (sep[1]) {
+		if (sep[0] && sep[1]) {
 			aux->sep = -1;
 			aux->tab[0] = aux->tab[1] = aux->tab[2] = aux->tab[3] = 0;
 			for (p = sep; *p; ++p) aux->tab[*p>>6] |= 1ull<<(*p&0x3f);
 		} else aux->sep = sep[0];
 	}
 	if (aux->finished) return 0;
-	else if (str) aux->p = str - 1, aux->finished = 0;
+	else if (str) start = (unsigned char *) str, aux->finished = 0;
+	else start = (unsigned char *) aux->p + 1;
 	if (aux->sep < 0) {
-		for (p = start = aux->p + 1; *p; ++p)
+		for (p = start; *p; ++p)
 			if (aux->tab[*p>>6]>>(*p&0x3f)&1) break;
 	} else {
-		for (p = start = aux->p + 1; *p; ++p)
+		for (p = start; *p; ++p)
 			if (*p == aux->sep) break;
 	}
-	aux->p = p; // end of token
+	aux->p = (const char *) p; // end of token
 	if (*p == 0) aux->finished = 1; // no more tokens
 	return (char*)start;
 }


### PR DESCRIPTION
Completes unfinished business from commit d8d0c5f which added the aux->finished flag, but failed to update the [line](https://github.com/attractivechaos/klib/blob/d8d0c5f/kstring.c#L31) that checks for the finished condition before processing `sep`.

Also fixes some bugs:

- Calling `kstrtok(str, "", aux);` would cause an illegal access to the byte after the `sep` string (and possibly beyond if that byte was not 0).
- On platforms where `char` is signed (usually the case on x86), calling `kstrtok(str, "\xff", aux)` would cause aux->sep to be set to -1 and not 255 as intended.  This results in the bitmap-based path being incorrectly used when scanning the string.
- The assignment `aux->p = str - 1` could result in undefined behaviour as `str - 1` may be outside the array object which contains the string.  This is not allowed by the C standard (see, for example, https://wiki.sei.cmu.edu/confluence/display/c/ARR30-C.+Do+not+form+or+use+out-of-bounds+pointers+or+array+subscripts), even if the pointer is never actually dereferenced.