### PR TITLE
Fixing a memory leak in knetfile.c.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ test/khash_keith2
 test/khash_test
 test/klist_test
 test/kmin_test
+test/knetfile_test
 test/kseq_bench
 test/kseq_bench2
 test/kseq_test

--- a/knetfile.c
+++ b/knetfile.c
@@ -582,6 +582,7 @@ int knet_close(knetFile *fp)
 	free(fp->host); free(fp->port);
 	free(fp->response); free(fp->retr); // FTP specific
 	free(fp->path); free(fp->http_host); // HTTP specific
+	free(fp->size_cmd);
 	free(fp);
 	return 0;
 }
@@ -591,7 +592,7 @@ int main(void)
 {
 	char *buf;
 	knetFile *fp;
-	int type = 4, l;
+	int type = 5, l;
 #ifdef _WIN32
 	knet_win32_init();
 #endif
@@ -615,7 +616,13 @@ int main(void)
 		knet_seek(fp, 20000, SEEK_SET);
 		knet_seek(fp, 10000, SEEK_SET);
 		l = knet_read(fp, buf+10000, 10000000) + 10000;
-	}
+	} else if (type == 5) {
+		fp = knet_open("http://archive.debian.org/debian/README", "r");
+		knet_read(fp, buf, 10000);
+		knet_seek(fp, 20000, SEEK_SET);
+		knet_seek(fp, 10000, SEEK_SET);
+		l = knet_read(fp, buf+10000, 10000000) + 10000;
+        }
 	if (type != 4 && type != 1) {
 		knet_read(fp, buf, 255);
 		buf[255] = 0;

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ CXX=g++
 CFLAGS=-g -Wall -O2 -I..
 CXXFLAGS=$(CFLAGS)
 PROGS=kbtree_test khash_keith khash_keith2 khash_test klist_test kseq_test kseq_bench \
-		kseq_bench2 ksort_test ksort_test-stl kvec_test kmin_test kstring_bench kstring_bench2 kstring_test \
+		kseq_bench2 ksort_test ksort_test-stl kvec_test kmin_test knetfile_test kstring_bench kstring_bench2 kstring_test \
 		kthread_test2
 
 all:$(PROGS)
@@ -46,6 +46,9 @@ kvec_test:kvec_test.cc ../kvec.h
 
 kmin_test:kmin_test.c ../kmath.h ../kmath.c
 		$(CC) $(CFLAGS) -o $@ kmin_test.c ../kmath.c
+
+knetfile_test:../knetfile.h ../knetfile.c
+		$(CC) $(CFLAGS) -DKNETFILE_MAIN -o $@ ../knetfile.c
 
 kstring_bench:kstring_bench.c ../kstring.h ../kstring.c
 		$(CC) $(CFLAGS) -o $@ kstring_bench.c ../kstring.c


### PR DESCRIPTION
fp->size_cmd is set to allocated memory in kftp_parse_url() but this is not freed by knet_close(). The fix should be safe in other cases as these allocate the memory of fp via calloc leaving fp->size_cmd equal to NULL by default, and free(NULL) is a nop (https://linux.die.net/man/3/free).

Adds a test that builds knetfile.c.