### PR TITLE
khash: factor out kh_release_*

### DIFF
--- a/khash.h
+++ b/khash.h
@@ -212,11 +212,16 @@ static const double __ac_HASH_UPPER = 0.77;
 	SCOPE kh_##name##_t *kh_init_##name(void) {							\
 		return (kh_##name##_t*)kcalloc(1, sizeof(kh_##name##_t));		\
 	}																	\
+	SCOPE void kh_release_##name(kh_##name##_t *h)						\
+	{																	\
+		kfree(h->flags);												\
+		kfree((void *)h->keys);											\
+		kfree((void *)h->vals);											\
+	}																	\
 	SCOPE void kh_destroy_##name(kh_##name##_t *h)						\
 	{																	\
 		if (h) {														\
-			kfree((void *)h->keys); kfree(h->flags);					\
-			kfree((void *)h->vals);										\
+			kh_release_##name(h);										\
 			kfree(h);													\
 		}																\
 	}																	\


### PR DESCRIPTION
Add a function for releasing only the internal memory of the khash structure, but not the structure itself.  This allows keeping that struct on the stack instead of allocating it using kh_init_*.