### PR TITLE
char *p to const char *p for const-correctness.

### DIFF
--- a/ketopt.h
+++ b/ketopt.h
@@ -89,7 +89,7 @@ static int ketopt(ketopt_t *s, int argc, char *argv[], int permute, const char *
 			}
 		}
 	} else { /* a short option */
-		char *p;
+		const char *p;
 		if (s->pos == 0) s->pos = 1;
 		opt = s->opt = argv[s->i][s->pos++];
 		p = strchr(ostr, opt);


### PR DESCRIPTION
In reference to https://github.com/attractivechaos/klib/issues/122, allows compilation with more compilers, depending on their strictness.

Thank you!