### PR TITLE
Allow the use of single-precision floating point math.

### DIFF
--- a/khash.h
+++ b/khash.h
@@ -189,7 +189,11 @@ typedef khint_t khiter_t;
 #define kfree(P) free(P)
 #endif
 
-static const double __ac_HASH_UPPER = 0.77;
+#ifndef kfloat
+typedef double kfloat;
+#endif
+
+static const kfloat __ac_HASH_UPPER = 0.77;
 
 #define __KHASH_TYPE(name, khkey_t, khval_t) \
 	typedef struct kh_##name##_s { \


### PR DESCRIPTION
Need to define `kfloat` as `float` and pass `-fsingle-precision-constant` (or
similar for other compilers.)