### PR TITLE
Apply seqtk PR to improve kseq.h parsing performance

### DIFF
--- a/kseq.h
+++ b/kseq.h
@@ -111,8 +111,8 @@ typedef struct __kstring_t {
 				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
 				i = sep != NULL ? sep - ks->buf : ks->end;				\
 			} else if (delimiter > KS_SEP_MAX) {						\
-				for (i = ks->begin; i < ks->end; ++i)					\
-					if (ks->buf[i] == delimiter) break;					\
+				unsigned char *sep = memchr(ks->buf + ks->begin, delimiter, ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end;				\
 			} else if (delimiter == KS_SEP_SPACE) {						\
 				for (i = ks->begin; i < ks->end; ++i)					\
 					if (isspace(ks->buf[i])) break;						\

--- a/kseq.h
+++ b/kseq.h
@@ -107,7 +107,7 @@ typedef struct __kstring_t {
 					if (ks->end == -1) { ks->is_eof = 1; return -3; }	\
 				} else break;											\
 			}															\
-			if (delimiter == KS_SEP_LINE) { \
+			if (delimiter == KS_SEP_LINE) {								\
 				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
 				i = sep != NULL ? sep - ks->buf : ks->end;				\
 			} else if (delimiter > KS_SEP_MAX) {						\

--- a/kseq.h
+++ b/kseq.h
@@ -108,8 +108,8 @@ typedef struct __kstring_t {
 				} else break;											\
 			}															\
 			if (delimiter == KS_SEP_LINE) { \
-				for (i = ks->begin; i < ks->end; ++i) \
-					if (ks->buf[i] == '\n') break; \
+				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end;				\
 			} else if (delimiter > KS_SEP_MAX) {						\
 				for (i = ks->begin; i < ks->end; ++i)					\
 					if (ks->buf[i] == delimiter) break;					\

--- a/test/kseq_bench2.c
+++ b/test/kseq_bench2.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include "kseq.h"
 KSTREAM_INIT(int, read, 4096)
 


### PR DESCRIPTION
This applies @kloetzl's lh3/seqtk#123 to klib's _kseq.h_.

For one large data file on my machine, this reduces _kseq_bench2_'s `kstream` time from ~1.65s to ~0.92s.
(I have not heavily tested it otherwise.)