### PR TITLE
Prevent constant strings warning in ketopt.h by g++

### DIFF
--- a/ketopt.h
+++ b/ketopt.h
@@ -17,7 +17,7 @@ typedef struct {
 } ketopt_t;
 
 typedef struct {
-	char *name;
+	char const *name;
 	int has_arg;
 	int val;
 } ko_longopt_t;


### PR DESCRIPTION
`ko_longopt_t.name` should be `char const *`.
When used in cpp, g++ will warn `ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]` on every `ko_longopt_t.name`.
