### PR TITLE
Fix void conversions in knetfile.c

### DIFF
--- a/knetfile.c
+++ b/knetfile.c
@@ -186,7 +186,7 @@ static off_t my_netread(int fd, void *buf, off_t len)
 	 * one call. They have to be called repeatedly. */
 	while (rest) {
 		if (socket_wait(fd, 1) <= 0) break; // socket is not ready for reading
-		curr = netread(fd, buf + l, rest);
+		curr = netread(fd, (char*)buf + l, rest);
 		/* According to the glibc manual, section 13.2, a zero returned
 		 * value indicates end-of-file (EOF), which should mean that
 		 * read() will not return zero if EOF has not been met but data
@@ -517,7 +517,7 @@ off_t knet_read(knetFile *fp, void *buf, off_t len)
 		off_t rest = len, curr;
 		while (rest) {
 			do {
-				curr = read(fp->fd, buf + l, rest);
+				curr = read(fp->fd, (char*)buf + l, rest);
 			} while (curr < 0 && EINTR == errno);
 			if (curr < 0) return -1;
 			if (curr == 0) break;


### PR DESCRIPTION
fixes:
error: invalid conversion from 'void*' to 'char*'  
warning: pointer of type 'void *' used in arithmetic